### PR TITLE
Correct two small typos in documentation

### DIFF
--- a/bst/tree.go
+++ b/bst/tree.go
@@ -78,7 +78,7 @@ func (t *BSTree) Upsert(key int64, payload interface{}) {
 	}
 }
 
-// Search searches for a for a node based on its key and returns the payload.
+// Search searches for a node based on its key and returns the payload.
 func (t *BSTree) Search(key int64) interface{} {
 	t.RLock()
 	defer t.RUnlock()

--- a/bst/types.go
+++ b/bst/types.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 )
 
-// BSTree represents a binary search tree with a root not and Mutex to protect
+// BSTree represents a binary search tree with a root node and Mutex to protect
 // concurrent access.
 type BSTree struct {
 	sync.RWMutex


### PR DESCRIPTION
Found two minor typos in comments/documentation.
